### PR TITLE
feat(ProjectGrid): Allow filtering by selecting projects on strapi

### DIFF
--- a/src/components/SliceRenderer/SliceRenderer.tsx
+++ b/src/components/SliceRenderer/SliceRenderer.tsx
@@ -195,6 +195,7 @@ export const SliceRenderer = ({
           return (
             <ProjectsGrid
               key={`${slice.__component}-${slice.id}`}
+              slice={slice}
               projects={projects}
             />
           );

--- a/src/constants/sectionsConfig.ts
+++ b/src/constants/sectionsConfig.ts
@@ -15,6 +15,7 @@ export const SECTIONS_WITH_BLOG_POSTS = [
 ];
 export const SECTIONS_WITH_CUSTOMER_STORIES = ['sections.customer-stories'];
 export const SECTIONS_WITH_PROJECTS = [
+  'sections.projects-grid',
   'sections.projects-map',
   'sections.project-facts',
 ];

--- a/src/slices/ProjectsGrid/ProjectsGrid.test.tsx
+++ b/src/slices/ProjectsGrid/ProjectsGrid.test.tsx
@@ -5,8 +5,12 @@ import { ProjectsGridProps } from './ProjectsGrid';
 import fpmProjectMock from '../../test/integrationMocks/fpmProjectMock';
 import { strapiMediaMock } from '../../test/strapiMocks/strapiMedia';
 import CreditsAvailableState from '../../models/CreditsAvailableState';
+import { strapiProjectMock } from '../../test/strapiMocks/strapiProject';
 
 const defaultProps: ProjectsGridProps = {
+  slice: {
+    projects: { data: [strapiProjectMock] },
+  },
   projects: [
     {
       ...fpmProjectMock,

--- a/src/slices/ProjectsGrid/ProjectsGrid.tsx
+++ b/src/slices/ProjectsGrid/ProjectsGrid.tsx
@@ -4,8 +4,12 @@ import Link from 'next/link';
 import { MEDIUM_TRANSITION_DURATION } from '../../constants/animations';
 import PortfolioProject from '../../models/PortfolioProject';
 import PortfolioProjectCard from '../../components/portfolio/PortfolioProjectCard';
+import { IStrapi, IStrapiData, StrapiProject } from '../..';
 
 export interface ProjectsGridProps {
+  slice: {
+    projects: IStrapi<IStrapiData<StrapiProject>[]>;
+  };
   projects: PortfolioProject[];
 }
 
@@ -21,9 +25,15 @@ const ConditionalWrapper = ({
 
 export const ProjectsGrid: React.FC<ProjectsGridProps> = ({
   projects,
+  slice,
 }: ProjectsGridProps) => {
   const filteredProjects = projects.filter(
-    (p) => p.thumbnail && p.slug && p.isPublic
+    (fpmProject) =>
+      fpmProject.thumbnail &&
+      slice.projects.data.some(
+        (strapiProject) =>
+          strapiProject.attributes.fpmProjectId === fpmProject.id
+      )
   );
 
   return (


### PR DESCRIPTION
In order to not display projects of different portfolios in the same section, we need to be able to somehow select individual projects.
I decided against letting the user select a portfolio and the displaying all projects of that portfolio because now this section can also be used in a blog post for example to highlight a few projects.