### PR TITLE
breaking: Remove BoemlyThemeProvider from ContextProvider

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -6,12 +6,13 @@ import rootMessagesEn from '../src/rootMessages.en';
 import { FONT_CUSTOMIZATIONS } from '../src/constants/fontCustomizations';
 import { Global } from '@emotion/react';
 import { GLOBAL_STYLE } from '../src/constants/globalStyle';
+import { FONT_STYLE } from '../src/constants/fontStyle';
 
 const preview: Preview = {
   decorators: [
     (Story) => (
       <>
-        <Global styles={{ GLOBAL_STYLE }} />
+        <Global styles={{ GLOBAL_STYLE, FONT_STYLE }} />
         <IntlProvider messages={rootMessagesEn} locale="en">
           <BoemlyThemeProvider fonts={FONT_CUSTOMIZATIONS}>
             <Story />

--- a/README.md
+++ b/README.md
@@ -63,17 +63,19 @@ Install the package:
 
 ```bash
 npm install @treely/strapi-slices
+npm install boemly
 ```
 
 Use the slices:
 
-```typescript
+```tsx
 import {
   IStrapiData,
   SliceRenderer,
   StrapiBlogPost,
   StrapiCustomerStory,
 } from '@treely/strapi-slices';
+import { BoemlyThemeProvider } from 'boemly';
 
 // Get the slices, blog posts, and customer stories from Strapi
 // Get the projects from the FPM API
@@ -83,11 +85,13 @@ const projects: PortfolioProject[] = [];
 const customerStories: IStrapiData<StrapiCustomerStory> = [];
 
 const App = (): JSX.Element => (
-  <SliceRenderer
-    slices={slices}
-    blogPosts={blogPosts}
-    projects={projects}
-    customerStories={customerStories}
-  />
+  <BoemlyThemeProvider>
+    <SliceRenderer
+      slices={slices}
+      blogPosts={blogPosts}
+      projects={projects}
+      customerStories={customerStories}
+    />
+  </BoemlyThemeProvider>
 );
 ```

--- a/src/components/ContextProvider/ContextProvider.tsx
+++ b/src/components/ContextProvider/ContextProvider.tsx
@@ -3,10 +3,8 @@ import { createIntl, createIntlCache } from 'react-intl';
 import rootMessagesDe from '../../rootMessages.de';
 import rootMessagesEn from '../../rootMessages.en';
 import Locale from '../../models/Locale';
-import { BoemlyThemeProvider } from 'boemly';
 import { Global } from '@emotion/react';
 import { GLOBAL_STYLE } from '../../constants/globalStyle';
-import { FONT_CUSTOMIZATIONS } from '../../constants/fontCustomizations';
 
 const cache = createIntlCache();
 
@@ -31,11 +29,11 @@ export const ContextProvider: React.FC<ContextProviderProps> = ({
   locale,
 }: ContextProviderProps): JSX.Element => {
   return (
-    <BoemlyThemeProvider fonts={FONT_CUSTOMIZATIONS}>
+    <>
       <Global styles={{ GLOBAL_STYLE }} />
       <IntlContext.Provider value={intlFactory(locale)}>
         {children}
       </IntlContext.Provider>
-    </BoemlyThemeProvider>
+    </>
   );
 };

--- a/src/constants/fontStyle.ts
+++ b/src/constants/fontStyle.ts
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+import { CDN_URI } from './api';
+
+export const FONT_STYLE = css`
+  // GintoNord
+  @font-face {
+    font-family: 'GintoNord';
+    src: url('${CDN_URI}/assets/v3/fonts/ABCGintoNord-Bold.woff2')
+      format('woff2');
+    font-style: normal;
+    font-weight: 700;
+    font-display: block;
+  }
+  // Inter
+  @font-face {
+    font-family: 'Inter';
+    src: url('${CDN_URI}/assets/v3/fonts/Inter-Regular.woff2') format('woff2');
+    font-style: normal;
+    font-weight: 400;
+    font-display: block;
+  }
+  @font-face {
+    font-family: 'Inter';
+    src: url('${CDN_URI}/assets/v3/fonts/Inter-Medium.woff2') format('woff2');
+    font-style: normal;
+    font-weight: 500;
+    font-display: block;
+  }
+  @font-face {
+    font-family: 'Inter';
+    src: url('${CDN_URI}/assets/v3/fonts/Inter-SemiBold.woff2') format('woff2');
+    font-style: normal;
+    font-weight: 600;
+    font-display: block;
+  }
+  @font-face {
+    font-family: 'Inter';
+    src: url('${CDN_URI}/assets/v3/fonts/Inter-Bold.woff2') format('woff2');
+    font-style: normal;
+    font-weight: 700;
+    font-display: block;
+  }
+  // SpaceMono
+  @font-face {
+    font-family: 'SpaceMono';
+    src: url('${CDN_URI}/assets/v3/fonts/SpaceMono-Bold.woff2') format('woff2');
+    font-style: normal;
+    font-weight: 700;
+    font-display: block;
+  }
+`;

--- a/src/constants/globalStyle.ts
+++ b/src/constants/globalStyle.ts
@@ -1,54 +1,6 @@
 import { css } from '@emotion/react';
-import { CDN_URI } from './api';
 
 export const GLOBAL_STYLE = css`
-  // GintoNord
-  @font-face {
-    font-family: 'GintoNord';
-    src: url('${CDN_URI}/assets/v3/fonts/ABCGintoNord-Bold.woff2')
-      format('woff2');
-    font-style: normal;
-    font-weight: 700;
-    font-display: block;
-  }
-  // Inter
-  @font-face {
-    font-family: 'Inter';
-    src: url('${CDN_URI}/assets/v3/fonts/Inter-Regular.woff2') format('woff2');
-    font-style: normal;
-    font-weight: 400;
-    font-display: block;
-  }
-  @font-face {
-    font-family: 'Inter';
-    src: url('${CDN_URI}/assets/v3/fonts/Inter-Medium.woff2') format('woff2');
-    font-style: normal;
-    font-weight: 500;
-    font-display: block;
-  }
-  @font-face {
-    font-family: 'Inter';
-    src: url('${CDN_URI}/assets/v3/fonts/Inter-SemiBold.woff2') format('woff2');
-    font-style: normal;
-    font-weight: 600;
-    font-display: block;
-  }
-  @font-face {
-    font-family: 'Inter';
-    src: url('${CDN_URI}/assets/v3/fonts/Inter-Bold.woff2') format('woff2');
-    font-style: normal;
-    font-weight: 700;
-    font-display: block;
-  }
-  // SpaceMono
-  @font-face {
-    font-family: 'SpaceMono';
-    src: url('${CDN_URI}/assets/v3/fonts/SpaceMono-Bold.woff2') format('woff2');
-    font-style: normal;
-    font-weight: 700;
-    font-display: block;
-  }
-
   :root {
     --default-hero-height: calc(100vh - var(--boemly-space-24));
   }

--- a/src/stories/Introduction.stories.mdx
+++ b/src/stories/Introduction.stories.mdx
@@ -11,3 +11,31 @@ It contains documentation for the Strapi sections that are implemented.
 Sections are pieces of the marketing part of the website that also exist as slices
 in our CMS (Strapi). So if you add a slice on, e.g. a page in Strapi,
 one of the sections will visualise the data.
+
+## Setup
+
+The components of this package need to be inside a `BoemlyThemeProvider`.
+This library will use all customizations that have been applied to the `BoemlyThemeProvider`.
+For more information, check out the documentation at [boemly.tree.ly](https://boemly.tree.ly/).
+
+```tsx
+import { BoemlyThemeProvider } from 'boemly';
+import { SliceRenderer } from '@treely/strapi-slices';
+
+const fonts = {
+  body: 'Ubuntu',
+  heading: 'Ubuntu',
+  display: 'Montserrat',
+  mono: 'JetbrainsMono',
+};
+
+function App({ props }) {
+  return (
+    <BoemlyThemeProvider fonts={fonts}>
+      <SliceRenderer {...props} />
+    </BoemlyThemeProvider>
+  );
+}
+
+export default App;
+```


### PR DESCRIPTION
BREAKING CHANGE:
The ContextProvider does not contain a BoemlyThemeProvider any more. Users are now required to set a BoemlyThemeProvider by themselves. This allows users to customize the fonts and colors that will be used by this librarys components. The setup/migration is documented in the README and the Storybook documentation.