### PR TITLE
perf: tune caching of Strapi fetchers

### DIFF
--- a/src/integrations/fpmClient.ts
+++ b/src/integrations/fpmClient.ts
@@ -8,7 +8,13 @@ const fpmClient = setupCache(
     baseURL: `${FPM_API_URI}/v1`,
     paramsSerializer: (p) => qs.stringify(p, { encodeValuesOnly: true }),
     timeout: 5000,
-  })
+  }),
+  {
+    ttl:
+      FPM_API_URI.includes('127.0.0.1') || FPM_API_URI.includes('localhost')
+        ? 0
+        : 10 * 60 * 1000, // 10 minutes
+  }
 );
 
 export default fpmClient;

--- a/src/integrations/strapi/getPortfolioProjects.ts
+++ b/src/integrations/strapi/getPortfolioProjects.ts
@@ -15,6 +15,7 @@ const getPortfolioProjects = async (
   locale: string = 'en',
   preview: boolean = false
 ): Promise<PortfolioProject[]> => {
+  const cache = preview ? false : undefined;
   const params: Record<string, any> = {
     populate: 'deep,6',
     locale,
@@ -30,17 +31,16 @@ const getPortfolioProjects = async (
     { data: strapiProjectsLocalized },
     { data: strapiProjectsEnglish },
   ] = await Promise.all([
-    fpmClient.get<FPMProject[]>('/public/projects'),
+    fpmClient.get<FPMProject[]>('/public/projects', { cache }),
     strapiClient.get<IStrapiResponse<IStrapiData<StrapiProject>[]>>(
       '/projects',
-      {
-        params,
-      }
+      { params, cache }
     ),
     strapiClient.get<IStrapiResponse<IStrapiData<StrapiProject>[]>>(
       '/projects',
       {
         params: { ...params, locale: FALLBACK_LOCALE },
+        cache,
       }
     ),
   ]);

--- a/src/integrations/strapi/getStaticPropsFromStrapi.ts
+++ b/src/integrations/strapi/getStaticPropsFromStrapi.ts
@@ -14,6 +14,7 @@ const getStaticPropsFromStrapi = async (
   path: string,
   { locale = 'en', slug, preview = false, filters = {} }: Options
 ): Promise<AxiosResponse> => {
+  const cache = preview ? false : undefined;
   const enrichedFilters: Record<string, string> = filters;
 
   if (slug) {
@@ -31,7 +32,7 @@ const getStaticPropsFromStrapi = async (
     params.publicationState = 'preview';
   }
 
-  return strapiClient.get(path, { params });
+  return strapiClient.get(path, { params, cache });
 };
 
 export default getStaticPropsFromStrapi;

--- a/src/integrations/strapi/getStrapiCollectionType.ts
+++ b/src/integrations/strapi/getStrapiCollectionType.ts
@@ -22,6 +22,7 @@ const getStrapiCollectionType = async <
   key: K,
   { locale = 'en', preview = false, filters = {} }: Options
 ): Promise<IStrapiData<T>[]> => {
+  const cache = preview ? false : undefined;
   const params: Record<string, any> = {
     populate: 'deep,6',
     locale: 'all',
@@ -35,7 +36,7 @@ const getStrapiCollectionType = async <
 
   const { data } = await strapiClient.get<IStrapiResponse<IStrapiData<T>[]>>(
     path,
-    { params }
+    { params, cache }
   );
 
   const localizedResponses = data.data.filter(

--- a/src/integrations/strapi/getStrapiSingleType.ts
+++ b/src/integrations/strapi/getStrapiSingleType.ts
@@ -17,6 +17,7 @@ const getStrapiSingleType = async <T>(
   path: string,
   { locale = 'en', preview = false, filters = {} }: Options
 ): Promise<IStrapiData<T>> => {
+  const cache = preview ? false : undefined;
   const params: Record<string, any> = {
     populate: 'deep,6',
     locale,
@@ -31,13 +32,14 @@ const getStrapiSingleType = async <T>(
   let response: AxiosResponse<IStrapiResponse<IStrapiData<T>>>;
 
   try {
-    response = await strapiClient.get(path, { params });
+    response = await strapiClient.get(path, { params, cache });
     return response.data.data;
   } catch (error: any) {
     if (error.isAxiosError && error.response?.status === 404) {
       // Retry request with fallback locale
       response = await strapiClient.get(path, {
         params: { ...params, locale: STRAPI_FALLBACK_LOCALE },
+        cache,
       });
 
       return response.data.data;

--- a/src/integrations/strapi/strapiClient.ts
+++ b/src/integrations/strapi/strapiClient.ts
@@ -8,7 +8,13 @@ const strapiClient = setupCache(
     baseURL: `${STRAPI_URI}/api`,
     paramsSerializer: (p) => qs.stringify(p, { encodeValuesOnly: true }),
     timeout: 60_000,
-  })
+  }),
+  {
+    ttl:
+      STRAPI_URI.includes('127.0.0.1') || STRAPI_URI.includes('localhost')
+        ? 0
+        : 10 * 60 * 1000, // 10 minutes
+  }
 );
 
 export default strapiClient;


### PR DESCRIPTION
* We need to disable caching on localhost, otherwise, you need to restart the app whenever you change something in Strapi.
* For the preview mode to work properly, we must also disable caching. 
* I set the default cache time-to-live to 10 minutes since the cache must only be valid until a build is done. 