### PR TITLE
fix(projectgrid): fix hover and wrap

### DIFF
--- a/src/components/ProjectGridCard/ProjectGridCard.tsx
+++ b/src/components/ProjectGridCard/ProjectGridCard.tsx
@@ -35,7 +35,7 @@ export const ProjectGridCard = ({
         <Heading my="4" size="lg">
           {project.title}
         </Heading>
-        <Flex flexDir="row" gap="2">
+        <Flex flexDir="row" gap="2" flexWrap="wrap">
           <Tag>
             <Text size="xsLowBold" color="gray.800">
               {formatNumber(
@@ -67,8 +67,8 @@ export const ProjectGridCard = ({
               </Text>
             </Tag>
           )}
+          <CreditsAvailableBadge status={project.creditAvailability} />
         </Flex>
-        <CreditsAvailableBadge status={project.creditAvailability} />
       </Flex>
     </Container>
   );

--- a/src/slices/ProjectsGrid/ProjectsGrid.tsx
+++ b/src/slices/ProjectsGrid/ProjectsGrid.tsx
@@ -60,6 +60,7 @@ export const ProjectsGrid: React.FC<ProjectsGridProps> = ({
               )}
             >
               <Box
+                height="full"
                 width="full"
                 as="a"
                 cursor="pointer"


### PR DESCRIPTION
- Added height='full' to ProjectGridCard to ensure it stretches within the grid, which also resolves the hover issue.
- Added <CreditsAvailableBadge /> inside Flex and applied wrap to prevent the text inside <Tag /> from breaking into two lines.

Preview: https://storybook-6pz34iqcr-treely.vercel.app/?path=/story/slices-projectsgrid--with-credits-availability-variants

