### PR TITLE
fix: fix the errors in projectgrid

### DIFF
--- a/src/components/CreditsAvailableBadge/CreditsAvailableBadge.tsx
+++ b/src/components/CreditsAvailableBadge/CreditsAvailableBadge.tsx
@@ -53,7 +53,7 @@ const CreditsAvailableBadge = ({
       as={href ? NextLink : undefined}
       href={href}
     >
-      <Tag backgroundColor={variant.color} mt="2" mb="1">
+      <Tag backgroundColor={variant.color}>
         <Text color="white" size="xsLowBold">
           {variant.message}
         </Text>

--- a/src/components/ProjectGridCard/ProjectGridCard.tsx
+++ b/src/components/ProjectGridCard/ProjectGridCard.tsx
@@ -17,7 +17,7 @@ export const ProjectGridCard = ({
   const { formatNumber, formatMessage } = useContext(IntlContext);
 
   return (
-    <Container>
+    <Container height="full">
       <Flex flexDir="column" height="full">
         {project.thumbnail && (
           <Box borderRadius="xl" position="relative" height="36" mb="2">

--- a/src/slices/ProjectsGrid/ProjectsGrid.tsx
+++ b/src/slices/ProjectsGrid/ProjectsGrid.tsx
@@ -60,8 +60,6 @@ export const ProjectsGrid: React.FC<ProjectsGridProps> = ({
               )}
             >
               <Box
-                height="full"
-                width="full"
                 as="a"
                 cursor="pointer"
                 borderRadius="2xl"

--- a/src/slices/ProjectsMap/MapMarker.tsx
+++ b/src/slices/ProjectsMap/MapMarker.tsx
@@ -5,7 +5,6 @@ import {
   Container,
   Flex,
   Heading,
-  Spacer,
   Text,
   useDisclosure,
   useToken,
@@ -70,9 +69,9 @@ const MapMarker = ({
               status={creditAvailability}
               href={slug && `${portfolioHost}/portfolio/${slug}`}
             />
-            <Spacer height="3" />
-
-            <Heading size="md">{title}</Heading>
+            <Heading mt="3" size="md">
+              {title}
+            </Heading>
 
             {projectDeveloper && (
               <Text size="smLowNormal" mt="1">


### PR DESCRIPTION
Preview: https://storybook-mphh3rpgo-treely.vercel.app/?path=/story/slices-projectsgrid--with-credits-availability-variants

Issues:
- The cards had different height on the screen width between 953px and 1053px. The fixed elementis used in `<TextWithCard />`, which is not influenced by this change: https://storybook-mphh3rpgo-treely.vercel.app/?path=/story/slices-textwithcard--with-projects
Original: https://storybook.tree.ly/?path=/story/slices-textwithcard--with-projects
- The tags had different height. The solution didn't influence the elements, where the `<CreditsAvailableBadge`, before `<Tag` , it was ` chakra-ui `<Badge` used in `<CreditsAvailableBadge`, that doesn't have margin.