### PR TITLE
fix: update text-carousel on mobile desktop

### DIFF
--- a/src/slices/TextCarousel/styles.ts
+++ b/src/slices/TextCarousel/styles.ts
@@ -39,6 +39,7 @@ export const CarouselInnerContainer = styled(
   min-width: var(--boemly-sizes-full);
 
   @media screen and (max-width: ${BREAKPOINT_MD}) {
+    gap: var(--boemly-space-1);
     justify-content: flex-start;
     width: calc(
       (var(--boemly-sizes-2xs) + var(--boemly-space-4)) *
@@ -52,7 +53,7 @@ export const CardContainer = styled(Box)`
   width: var(--boemly-sizes-sm);
 
   @media screen and (max-width: ${BREAKPOINT_MD}) {
-    width: var(--boemly-sizes-2xs);
+    min-width: var(--boemly-sizes-sm);
 
     margin-right: var(--boemly-space-4);
 


### PR DESCRIPTION
Impediment: https://trello.com/c/XFwVo7CR/602-textcarousel-update-for-mobile-desktop
This PR fixes the problems of TextCarousel on mobile desktop:
- too narrow cards;
- too big gap between the cards

![IMG_4514](https://github.com/user-attachments/assets/4d0a6f67-2bcb-4883-a1c8-72b6ce098be2)

Screenshot of fixed component:
![Screenshot 2024-10-25 at 10 46 22](https://github.com/user-attachments/assets/74ea031c-5e31-470c-87d2-999cf288c130)
![Screenshot 2024-10-25 at 10 46 33](https://github.com/user-attachments/assets/0c7b099f-354d-4c9d-a2f5-f84c41834753)

