### PR TITLE
fix: no scroll on the FullWidthImageSlider when captions  are long

### DIFF
--- a/src/slices/FullWidthImageSlider/FullWidthImageSlider.tsx
+++ b/src/slices/FullWidthImageSlider/FullWidthImageSlider.tsx
@@ -118,7 +118,10 @@ export const FullWidthImageSlider: React.FC<FullWidthImageSliderProps> = ({
                     }}
                   />
                 </ImageContainer>
-                <Text height="6">{image.caption}</Text>
+
+                <Text noOfLines={3} height="72px" fontSize="md">
+                  {image.caption}
+                </Text>
               </Flex>
             </ItemContainer>
           ))}


### PR DESCRIPTION
Impediment: https://trello.com/c/LbKMBguc/680-fullwidthimageslider-is-verticall-scrollable