### PR TITLE
fix: fetch of collection type

### DIFF
--- a/src/integrations/strapi/getAllSlugsFromStrapi.test.ts
+++ b/src/integrations/strapi/getAllSlugsFromStrapi.test.ts
@@ -44,7 +44,7 @@ describe('The getAllSlugsFromStrapi function', () => {
           ],
         },
       })
-      .mockResolvedValueOnce({ data: { data: [] } });
+      .mockRejectedValueOnce({ response: { status: 404 } }); // Hungarian version is missing (404)
 
     const slugs = await slugsPromise;
 

--- a/src/integrations/strapi/getStrapiCollectionType.test.ts
+++ b/src/integrations/strapi/getStrapiCollectionType.test.ts
@@ -74,8 +74,8 @@ describe('The getStrapiCollectionType function', () => {
 
     MockAxios.get
       .mockResolvedValueOnce({ data: { data: [strapiPageMock] } }) // english
-      .mockResolvedValueOnce({ data: { data: [] } })
-      .mockResolvedValueOnce({ data: { data: [] } });
+      .mockRejectedValueOnce({ response: { status: 404 } }) // Hungarian version is missing (404)
+      .mockRejectedValueOnce({ response: { status: 404 } }); // German version is missing (404)
 
     const pages = getStrapiCollectionType<StrapiPage, 'slug'>(
       '/api/pages',


### PR DESCRIPTION
# Problem description
When sending a request to get a collection type page with a locale for which no translation exists, we get a 404 not found error. Now I implemented the error handling. It catches the error, fills in an empty array and, as before, the empty array gets replaced by the fallback page.
<img width="675" alt="image" src="https://github.com/user-attachments/assets/0c176fac-a8aa-497b-b57c-d69ced082427" />

This error doesn't appear for all requests. Sometimes we get an empty array back... that's why I didn't find this bug earlier.
<img width="630" alt="image" src="https://github.com/user-attachments/assets/c3995810-37e0-4e70-863d-b79a0093d1ac" />


I did the same for getAllSlugsFromStrapi.
