### PR TITLE
fix: fallback logic

### DIFF
--- a/src/integrations/strapi/getStrapiCollectionType.ts
+++ b/src/integrations/strapi/getStrapiCollectionType.ts
@@ -66,14 +66,18 @@ const getStrapiCollectionType = async <
       throw error;
     });
 
-  const results = fallbackLocaleData.map((fallbackLocaleDataEntry) => {
-    const requestedLocale = requestedLocaleData.find(
-      (localized) =>
-        localized.attributes[key] === fallbackLocaleDataEntry.attributes[key]
-    );
+  const results =
+    fallbackLocaleData.length === 0
+      ? requestedLocaleData
+      : fallbackLocaleData.map((fallbackLocaleDataEntry) => {
+          const requestedLocale = requestedLocaleData.find(
+            (localized) =>
+              localized.attributes[key] ===
+              fallbackLocaleDataEntry.attributes[key]
+          );
 
-    return requestedLocale || fallbackLocaleDataEntry;
-  });
+          return requestedLocale || fallbackLocaleDataEntry;
+        });
 
   return results;
 };


### PR DESCRIPTION
When rewriting tests in app one test was just not working. During debugging I discovered that if the fallbackLocaleData is empty the result is always empty. This is not right. When the fallbackLocaleData is empty it should take the requestedLocaleData.