### PR TITLE
feat: add yearly sellable amount to project info

### DIFF
--- a/src/components/portfolio/ProjectInfo/ProjectInfo.test.tsx
+++ b/src/components/portfolio/ProjectInfo/ProjectInfo.test.tsx
@@ -20,7 +20,8 @@ const defaultProps: ProjectInfoProps = {
     projectTypeSubtitle: 'Project type subtitle',
     projectDeveloperSubtitle: 'Project developer subtitle',
     verificationStandardSubtitle: 'Verification standard subtitle',
-    forecastedAmountSubtitle: 'Forecasted amount subtitle',
+    averageSellableAmountPerYearSubtitle:
+      'Average sellable amount per year subtitle',
     riskBufferSubtitle: 'Risk buffer subtitle',
     buyCreditsSubtitle: 'Buy credits subtitle',
   },
@@ -54,7 +55,9 @@ describe('The ProjectInfo component', () => {
     expect(
       screen.getByText('Verification standard subtitle')
     ).toBeInTheDocument();
-    expect(screen.getByText('Forecasted amount subtitle')).toBeInTheDocument();
+    expect(
+      screen.getByText('Average sellable amount per year subtitle')
+    ).toBeInTheDocument();
     expect(screen.getByText('Risk buffer subtitle')).toBeInTheDocument();
   });
 
@@ -72,12 +75,14 @@ describe('The ProjectInfo component', () => {
     expect(screen.getByText('1 year')).toBeInTheDocument();
   });
 
-  it('sets the tooltip when hovered over the forecasted amount subtitle', async () => {
+  it('sets the tooltip when hovered over the average sellable amount per year subtitle', async () => {
     setup({
       ...defaultProps,
     });
 
-    const trigger = screen.getByText('Forecasted amount subtitle');
+    const trigger = screen.getByText(
+      'Average sellable amount per year subtitle'
+    );
     await userEvent.hover(trigger);
 
     const tooltip = await screen.findByRole('tooltip');

--- a/src/components/portfolio/ProjectInfo/ProjectInfo.tsx
+++ b/src/components/portfolio/ProjectInfo/ProjectInfo.tsx
@@ -32,7 +32,7 @@ export interface ProjectInfoProps {
     projectTypeSubtitle?: string;
     projectDeveloperSubtitle?: string;
     verificationStandardSubtitle?: string;
-    forecastedAmountSubtitle?: string;
+    averageSellableAmountPerYearSubtitle?: string;
     riskBufferSubtitle?: string;
     buyCreditsSubtitle?: string;
   };
@@ -196,57 +196,61 @@ export const ProjectInfo: React.FC<ProjectInfoProps> = ({
         <></>
       )}
 
-      {project.forecastedAmountYearly && project.riskBuffer ? (
+      {project.averageSellableAmountPerYear !== 0 || project.riskBuffer ? (
         <>
           <Spacer height="8" />
           <Divider />
           <Spacer height="8" />
-          <SimpleGrid columns={[1, null, null, 2]} spacingX="10" spacingY="8">
-            <Tooltip
-              label={formatMessage({
-                id: 'features.projectInfo.properties.forecastedAmountYear.toolTip',
-              })}
-            >
-              <Box>
-                <LabelTextPair
-                  label={formatMessage({
-                    id: 'features.projectInfo.properties.forecastedAmountYear.label',
-                  })}
-                  text={formatMessage(
-                    {
-                      id: 'unit.formatter.tonsCo2PerYear',
-                    },
-                    {
-                      number: formatNumber(
-                        convertCo2AmountKgToTons(
-                          project.forecastedAmountYearly.toString()
-                        ),
-                        { maximumFractionDigits: 0 }
-                      ),
-                    }
-                  )}
-                  caption={subtitles.forecastedAmountSubtitle}
-                />
-              </Box>
-            </Tooltip>
-
-            <Box>
-              <LabelTextPair
-                label={formatMessage({
-                  id: 'features.projectInfo.properties.riskBuffer',
-                })}
-                text={formatNumber(
-                  project.riskBuffer / 100,
-                  FORMAT_AS_PERCENT_CONFIG
-                )}
-                caption={subtitles.riskBufferSubtitle}
-              />
-            </Box>
-          </SimpleGrid>
         </>
       ) : (
         <></>
       )}
+      <SimpleGrid columns={[1, null, null, 2]} spacingX="10" spacingY="8">
+        {project.averageSellableAmountPerYear !== 0 && (
+          <Tooltip
+            label={formatMessage({
+              id: 'features.projectInfo.properties.forecastedAmountYear.toolTip',
+            })}
+          >
+            <Box>
+              <LabelTextPair
+                label={formatMessage({
+                  id: 'features.projectInfo.properties.forecastedAmountYear.label',
+                })}
+                text={formatMessage(
+                  {
+                    id: 'unit.formatter.tonsCo2PerYear',
+                  },
+                  {
+                    number: formatNumber(
+                      convertCo2AmountKgToTons(
+                        project.averageSellableAmountPerYear.toString()
+                      ),
+                      { maximumFractionDigits: 0 }
+                    ),
+                  }
+                )}
+                caption={subtitles.averageSellableAmountPerYearSubtitle}
+              />
+            </Box>
+          </Tooltip>
+        )}
+
+        {project.riskBuffer && (
+          <Box>
+            <LabelTextPair
+              label={formatMessage({
+                id: 'features.projectInfo.properties.riskBuffer',
+              })}
+              text={formatNumber(
+                project.riskBuffer / 100,
+                FORMAT_AS_PERCENT_CONFIG
+              )}
+              caption={subtitles.riskBufferSubtitle}
+            />
+          </Box>
+        )}
+      </SimpleGrid>
 
       <Box mt="2">
         <CreditsAvailableBadge status={project.creditAvailability} />

--- a/src/components/portfolio/ProjectInfo/messages.de.ts
+++ b/src/components/portfolio/ProjectInfo/messages.de.ts
@@ -13,7 +13,7 @@ const messagesDe = {
   'features.projectInfo.properties.verificationStandard.value.MfKWCH':
     'Methodik für Klimaschutzprojekte im Wald für die Schweiz',
   'features.projectInfo.properties.forecastedAmountYear.toolTip':
-    'Dies ist das jährliche Projekt-Senkenvolumen gemäß dem TÜV-geprüften PDD, dieser Wert stellt nicht die aktuellen Verfügbarkeiten dar.',
+    'Dies ist der jährlich verkaufbare Betrag an Credits pro Jahr im Durchschnitt. Dieser Wert repräsentiert nicht die Verfügbarkeiten.',
   'features.projectInfo.properties.forecastedAmountYear.label':
     'Projektvolumen',
   'features.projectInfo.properties.riskBuffer': 'Anteil Risikopuffer',

--- a/src/components/portfolio/ProjectInfo/messages.en.ts
+++ b/src/components/portfolio/ProjectInfo/messages.en.ts
@@ -15,7 +15,7 @@ const messagesEn = {
   'features.projectInfo.properties.forecastedAmountYear.label':
     'Project Volume',
   'features.projectInfo.properties.forecastedAmountYear.toolTip':
-    "This is the yearly project sink volume according to the TÜV-verified PDD, this value doesn't represent current availabilities.",
+    "This is the average amount of credits that are issued per year. This value doesn't represent availabilities.",
   'features.projectInfo.properties.riskBuffer': 'Risk Buffer Share',
 
   'features.projectInfo.properties.year':

--- a/src/integrations/strapi/getPortfolioProjects.test.ts
+++ b/src/integrations/strapi/getPortfolioProjects.test.ts
@@ -2,55 +2,76 @@ import MockAxios from 'jest-mock-axios';
 import fpmProjectMock from '../../test/integrationMocks/fpmProjectMock';
 import { strapiProjectMock } from '../../test/strapiMocks/strapiProject';
 import getPortfolioProjects from './getPortfolioProjects';
+import fpmClient from '../fpmClient';
+import strapiClient from './strapiClient';
+
+// Mock the fpmClient module
+jest.mock('../fpmClient', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
+
+// Mock the strapiClient module
+jest.mock('./strapiClient', () => ({
+  __esModule: true,
+  default: {
+    get: jest.fn(),
+  },
+}));
 
 describe('The getPortfolioProjects function', () => {
   afterEach(() => {
     MockAxios.reset();
+    jest.clearAllMocks();
   });
 
   it('returns the FPM projects with the slug from strapi', async () => {
-    const projectsPromise = getPortfolioProjects();
+    // Mock fpmClient responses
+    (fpmClient.get as jest.Mock)
+      .mockResolvedValueOnce({ data: [fpmProjectMock] }) // /public/projects
+      .mockResolvedValueOnce({
+        data: { ...fpmProjectMock, averageSellableAmountPerYear: 1000 },
+      }); // /public/projects/${id}
 
-    MockAxios.mockResponseFor(
-      { url: '/public/projects' },
-      { data: [fpmProjectMock] }
-    );
-    MockAxios.mockResponseFor(
-      { url: '/projects' },
-      { data: { data: [strapiProjectMock] } }
-    );
-    MockAxios.mockResponseFor({ url: '/projects' }, { data: { data: [] } });
+    // Mock strapiClient responses
+    (strapiClient.get as jest.Mock)
+      .mockResolvedValueOnce({ data: { data: [strapiProjectMock] } }) // First /projects call
+      .mockResolvedValueOnce({ data: { data: [] } }); // Second /projects call
 
-    const projects = await projectsPromise;
+    const projects = await getPortfolioProjects();
 
     expect(projects.length).toBe(1);
     expect(projects[0]).toStrictEqual({
       ...fpmProjectMock,
       slug: strapiProjectMock.attributes.slug,
       creditAvailability: fpmProjectMock.creditAvailability,
+      averageSellableAmountPerYear: 1000,
     });
   });
 
   it('returns the FPM project in english if no localized version is available', async () => {
-    const projectsPromise = getPortfolioProjects('de');
+    // Mock fpmClient responses
+    (fpmClient.get as jest.Mock)
+      .mockResolvedValueOnce({ data: [fpmProjectMock] }) // /public/projects
+      .mockResolvedValueOnce({
+        data: { ...fpmProjectMock, averageSellableAmountPerYear: 1000 },
+      }); // /public/projects/${id}
 
-    MockAxios.mockResponseFor(
-      { url: '/public/projects' },
-      { data: [fpmProjectMock] }
-    );
-    MockAxios.mockResponseFor({ url: '/projects' }, { data: { data: [] } });
-    MockAxios.mockResponseFor(
-      { url: '/projects' },
-      { data: { data: [strapiProjectMock] } }
-    );
+    // Mock strapiClient responses
+    (strapiClient.get as jest.Mock)
+      .mockResolvedValueOnce({ data: { data: [] } }) // First /projects call (localized)
+      .mockResolvedValueOnce({ data: { data: [strapiProjectMock] } }); // Second /projects call (english fallback)
 
-    const projects = await projectsPromise;
+    const projects = await getPortfolioProjects('de');
 
     expect(projects.length).toBe(1);
     expect(projects[0]).toStrictEqual({
       ...fpmProjectMock,
       slug: strapiProjectMock.attributes.slug,
       creditAvailability: fpmProjectMock.creditAvailability,
+      averageSellableAmountPerYear: 1000,
     });
   });
 });

--- a/src/models/fpm/FPMProject.ts
+++ b/src/models/fpm/FPMProject.ts
@@ -42,6 +42,7 @@ interface FPMProject {
     updatedAt: Date;
   };
   forecastedAmountYearly?: number;
+  averageSellableAmountPerYear: number;
   riskBuffer?: number;
   defaultIssuer?: Issuer;
   creditAvailability: CreditAvailability;

--- a/src/slices/ProjectFacts/ProjectFacts.stories.tsx
+++ b/src/slices/ProjectFacts/ProjectFacts.stories.tsx
@@ -77,7 +77,8 @@ FullProps.args = {
     projectTypeSubtitle: 'Project Type Subtitle',
     projectDeveloperSubtitle: 'Project Developer Subtitle',
     verificationStandardSubtitle: 'Verification Standard Subtitle',
-    forecastedAmountSubtitle: 'Forecasted Amount Subtitle',
+    averageSellableAmountPerYearSubtitle:
+      'Average Sellable Amount Per Year Subtitle',
     riskBufferSubtitle: 'Risk Buffer Subtitle',
 
     customTitle: 'Looking to buy more than 10.000 tCO₂?',

--- a/src/slices/ProjectFacts/ProjectFacts.tsx
+++ b/src/slices/ProjectFacts/ProjectFacts.tsx
@@ -32,7 +32,7 @@ export interface ProjectFactsProps {
     projectTypeSubtitle?: string;
     projectDeveloperSubtitle?: string;
     verificationStandardSubtitle?: string;
-    forecastedAmountSubtitle?: string;
+    averageSellableAmountPerYearSubtitle?: string;
     riskBufferSubtitle?: string;
     buyCreditsSubtitle?: string;
 

--- a/src/slices/TextWithCard/TextWithCard.stories.tsx
+++ b/src/slices/TextWithCard/TextWithCard.stories.tsx
@@ -68,6 +68,7 @@ const portfolioProject: PortfolioProject = {
     updatedAt: new Date('2020-01-01'),
   },
   forecastedAmountYearly: 100,
+  averageSellableAmountPerYear: 80,
   riskBuffer: 10,
   createdAt: new Date('2020-01-01'),
   updatedAt: new Date('2020-01-01'),

--- a/src/test/integrationMocks/fpmProjectMock.ts
+++ b/src/test/integrationMocks/fpmProjectMock.ts
@@ -30,6 +30,7 @@ const fpmProjectMock: FPMProject = {
     updatedAt: new Date('2020-01-01'),
   },
   forecastedAmountYearly: 100,
+  averageSellableAmountPerYear: 800000,
   riskBuffer: 10,
   createdAt: new Date('2020-01-01'),
   updatedAt: new Date('2020-01-01'),


### PR DESCRIPTION
Because the result of the findAll endpoint is passed to the ProjectFacts slice, we would need to calculate the `averageSellableAmountPerYear` for each project in the findAll. That's not a good solution. 

The best solution that Roman and me found is to implement the calculation of the `averageSellableAmountPerYear` in the findOne and then fetch the findOne Project in the strapi-slices package.

Downside: The build is going to take longer.